### PR TITLE
Force Heroku to rebuild on all deployments

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,0 +1,1 @@
+always_rebuild=true


### PR DESCRIPTION
Upgrading Phoenix requires all packages to be rebuilt, which Heroku does not do
by default.
