### PR TITLE
Change post content to type text

### DIFF
--- a/priv/repo/migrations/20151111033002_create_post.exs
+++ b/priv/repo/migrations/20151111033002_create_post.exs
@@ -4,7 +4,7 @@ defmodule PhoenixBlog.Repo.Migrations.CreatePost do
   def change do
     create table(:posts) do
       add :title, :string
-      add :content, :string
+      add :content, :text
 
       timestamps
     end

--- a/test/models/post_test.exs
+++ b/test/models/post_test.exs
@@ -1,17 +1,25 @@
+defmodule StringGen do
+  def random_string(length) do
+    :crypto.strong_rand_bytes(length)
+    |> Base.url_encode64
+    |> binary_part(0, length)
+  end
+end
+
 defmodule PhoenixBlog.PostTest do
   use PhoenixBlog.ModelCase
 
   alias PhoenixBlog.Post
 
-  @valid_attrs %{content: "some content", title: "some content"}
+  @valid_attrs %{content: StringGen.random_string(1000), title: "some content"}
   @invalid_attrs %{}
 
-  test "changeset with valid attributes" do
+  test "changeset with valid attributes is valid" do
     changeset = Post.changeset(%Post{}, @valid_attrs)
     assert changeset.valid?
   end
 
-  test "changeset with invalid attributes" do
+  test "changeset with invalid attributes is not valid" do
     changeset = Post.changeset(%Post{}, @invalid_attrs)
     refute changeset.valid?
   end


### PR DESCRIPTION
WHY:
- The `sting` type has a length limit, but a post's content should not
